### PR TITLE
Fix neutral case & New Pokemon matchup interface

### DIFF
--- a/src/components/MatchupAnalysis.vue
+++ b/src/components/MatchupAnalysis.vue
@@ -23,16 +23,16 @@ watch(props, async () => {
     const opponentName = pokemonOpponentObj.name;
     const pM: PokemonMatchup = getPokemonMatchup(pokemonYouObj, pokemonOpponentObj);
 
-    const yourTypeKeys = Object.keys(pM.yourTypeA);
-    for (let index = 0; index < yourTypeKeys.length; index += 1) {
-        const type = yourTypeKeys[index];
-        const effectiveness = pM.yourTypeA[type] > 0 ? 'Strong' : 'Weak';
+    const toTypes = Object.keys(pM.to);
+    for (let index = 0; index < toTypes.length; index += 1) {
+        const type = toTypes[index];
+        const effectiveness = pM.to[type] > 0 ? 'Strong' : 'Weak';
         items.push(`Your ${type} type is ${effectiveness} attacking ${opponentName}`);
     }
-    const opponentTypeKeys = Object.keys(pM.opponentTypeA);
-    for (let index = 0; index < opponentTypeKeys.length; index += 1) {
-        const type = opponentTypeKeys[index];
-        const effectiveness = pM.opponentTypeA[type] > 0 ? 'Strong' : 'Weak';
+    const fromTypes = Object.keys(pM.from);
+    for (let index = 0; index < fromTypes.length; index += 1) {
+        const type = fromTypes[index];
+        const effectiveness = pM.from[type] > 0 ? 'Strong' : 'Weak';
         items.push(`Their ${type} type is ${effectiveness} attacking your ${yourName}`);
     }
     analysisResults.value = items;

--- a/src/components/MatchupAnalysis.vue
+++ b/src/components/MatchupAnalysis.vue
@@ -3,6 +3,7 @@ import { defineProps, ref, watch } from 'vue';
 import { HomePageModel } from '@/ts/component_interfaces';
 import { Type } from '@/ts/types';
 import { getPokemonById } from '@/ts/pokemon';
+import { PokemonMatchup, getPokemonMatchup } from '@/ts/pokemon_matchup';
 
 const props = defineProps<{
     modelValue: HomePageModel,
@@ -20,42 +21,20 @@ watch(props, async () => {
     const items: string[] = [];
     const yourName = pokemonYouObj.name;
     const opponentName = pokemonOpponentObj.name;
-    const yourTypes = pokemonYouObj.types;
-    const opponentTypeNames = pokemonOpponentObj.types.map((type: Type) => type.name);
-    const yourTypeIsStrong : Set<string> = new Set();
-    const yourTypeIsWeak : Set<string> = new Set();
-    const opponentTypeIsStrong : Set<string> = new Set();
-    const opponentTypeIsWeak : Set<string> = new Set();
+    const pM: PokemonMatchup = getPokemonMatchup(pokemonYouObj, pokemonOpponentObj);
 
-    for (let ii = 0; ii < yourTypes.length; ii += 1) {
-        const yourType = yourTypes[ii].name;
-        const matchups = yourTypes[ii].versions.latest; // @TODO use generation here
-        for (let jj = 0; jj < opponentTypeNames.length; jj += 1) {
-            const opponentType = opponentTypeNames[jj];
-            if (matchups.doubleDamageTo.includes(opponentType)) {
-                yourTypeIsStrong.add(yourType);
-            }
-            if (matchups.halfDamageTo.includes(opponentType)) {
-                yourTypeIsWeak.add(yourType);
-            }
-            if (matchups.noDamageTo.includes(opponentType)) {
-                yourTypeIsWeak.add(yourType);
-            }
-            if (matchups.doubleDamageFrom.includes(opponentType)) {
-                opponentTypeIsStrong.add(opponentType);
-            }
-            if (matchups.halfDamageFrom.includes(opponentType)) {
-                opponentTypeIsWeak.add(opponentType);
-            }
-            if (matchups.noDamageFrom.includes(opponentType)) {
-                opponentTypeIsWeak.add(opponentType);
-            }
-        }
+    const yourTypeKeys = Object.keys(pM.yourTypeA);
+    for (let index = 0; index < yourTypeKeys.length; index += 1) {
+        const type = yourTypeKeys[index];
+        const effectiveness = pM.yourTypeA[type] > 0 ? 'Strong' : 'Weak';
+        items.push(`Your ${type} type is ${effectiveness} attacking ${opponentName}`);
     }
-    yourTypeIsStrong.forEach((type: string) => items.push(`Your ${type} type is Strong attacking ${opponentName}`));
-    yourTypeIsWeak.forEach((type: string) => items.push(`Your ${type} type is Weak attacking ${opponentName}`));
-    opponentTypeIsStrong.forEach((type: string) => items.push(`Their ${type} type is Strong attacking your ${yourName}`));
-    opponentTypeIsWeak.forEach((type: string) => items.push(`Their ${type} type is Weak attacking your ${yourName}`));
+    const opponentTypeKeys = Object.keys(pM.opponentTypeA);
+    for (let index = 0; index < opponentTypeKeys.length; index += 1) {
+        const type = opponentTypeKeys[index];
+        const effectiveness = pM.opponentTypeA[type] > 0 ? 'Strong' : 'Weak';
+        items.push(`Their ${type} type is ${effectiveness} attacking your ${yourName}`);
+    }
     analysisResults.value = items;
 }, {
     immediate: true,

--- a/src/ts/pokemon.ts
+++ b/src/ts/pokemon.ts
@@ -4,7 +4,7 @@ import { buildType, Type } from './types';
 
 const BASE_URL = 'https://pokeapi.co/api/v2/';
 
-interface Pokemon {
+export interface Pokemon {
     name: string;
     types: Type[];
     id: string;

--- a/src/ts/pokemon_matchup.ts
+++ b/src/ts/pokemon_matchup.ts
@@ -1,0 +1,50 @@
+import { Pokemon } from './pokemon';
+import { Type } from './types';
+
+export interface PokemonMatchup {
+    yourTypeA: { [type: string]: number};
+    opponentTypeA: { [type: string]: number};
+}
+
+export function getPokemonMatchup(pokemonYou: Pokemon, pokemonOpponent: Pokemon): PokemonMatchup {
+    const yourTypes = pokemonYou.types;
+    const opponentTypeNames = pokemonOpponent.types.map((type: Type) => type.name);
+    const pM: PokemonMatchup = {
+        yourTypeA: {},
+        opponentTypeA: {},
+    };
+    for (let ii = 0; ii < yourTypes.length; ii += 1) {
+        const yourType = yourTypes[ii].name;
+        const matchups = yourTypes[ii].versions.latest; // @TODO use generation here
+        for (let jj = 0; jj < opponentTypeNames.length; jj += 1) {
+            const opponentType = opponentTypeNames[jj];
+            if (matchups.doubleDamageTo.includes(opponentType)) {
+                pM.yourTypeA[yourType] = (pM.yourTypeA[yourType] || 0) + 1;
+            }
+            if (matchups.halfDamageTo.includes(opponentType)) {
+                pM.yourTypeA[yourType] = (pM.yourTypeA[yourType] || 0) - 1;
+            }
+            if (matchups.noDamageTo.includes(opponentType)) {
+                pM.yourTypeA[yourType] = (pM.yourTypeA[yourType] || 0) - 1;
+            }
+            if (matchups.doubleDamageFrom.includes(opponentType)) {
+                pM.opponentTypeA[opponentType] = (pM.opponentTypeA[opponentType] || 0) + 1;
+            }
+            if (matchups.halfDamageFrom.includes(opponentType)) {
+                pM.opponentTypeA[opponentType] = (pM.opponentTypeA[opponentType] || 0) - 1;
+            }
+            if (matchups.noDamageFrom.includes(opponentType)) {
+                pM.opponentTypeA[opponentType] = (pM.opponentTypeA[opponentType] || 0) - 1;
+            }
+            // filter out "neutral" matchups
+            if (pM.yourTypeA[yourType] === 0) {
+                delete pM.yourTypeA[yourType];
+            }
+            if (pM.opponentTypeA[opponentType] === 0) {
+                delete pM.opponentTypeA[opponentType];
+            }
+        }
+    }
+
+    return pM;
+}

--- a/src/ts/pokemon_matchup.ts
+++ b/src/ts/pokemon_matchup.ts
@@ -2,16 +2,16 @@ import { Pokemon } from './pokemon';
 import { Type } from './types';
 
 export interface PokemonMatchup {
-    yourTypeA: { [type: string]: number};
-    opponentTypeA: { [type: string]: number};
+    to: { [type: string]: number};
+    from: { [type: string]: number};
 }
 
 export function getPokemonMatchup(pokemonYou: Pokemon, pokemonOpponent: Pokemon): PokemonMatchup {
     const yourTypes = pokemonYou.types;
     const opponentTypeNames = pokemonOpponent.types.map((type: Type) => type.name);
     const pM: PokemonMatchup = {
-        yourTypeA: {},
-        opponentTypeA: {},
+        to: {},
+        from: {},
     };
     for (let ii = 0; ii < yourTypes.length; ii += 1) {
         const yourType = yourTypes[ii].name;
@@ -19,29 +19,29 @@ export function getPokemonMatchup(pokemonYou: Pokemon, pokemonOpponent: Pokemon)
         for (let jj = 0; jj < opponentTypeNames.length; jj += 1) {
             const opponentType = opponentTypeNames[jj];
             if (matchups.doubleDamageTo.includes(opponentType)) {
-                pM.yourTypeA[yourType] = (pM.yourTypeA[yourType] || 0) + 1;
+                pM.to[yourType] = (pM.to[yourType] || 0) + 1;
             }
             if (matchups.halfDamageTo.includes(opponentType)) {
-                pM.yourTypeA[yourType] = (pM.yourTypeA[yourType] || 0) - 1;
+                pM.to[yourType] = (pM.to[yourType] || 0) - 1;
             }
             if (matchups.noDamageTo.includes(opponentType)) {
-                pM.yourTypeA[yourType] = (pM.yourTypeA[yourType] || 0) - 1;
+                pM.to[yourType] = (pM.to[yourType] || 0) - 1;
             }
             if (matchups.doubleDamageFrom.includes(opponentType)) {
-                pM.opponentTypeA[opponentType] = (pM.opponentTypeA[opponentType] || 0) + 1;
+                pM.from[opponentType] = (pM.from[opponentType] || 0) + 1;
             }
             if (matchups.halfDamageFrom.includes(opponentType)) {
-                pM.opponentTypeA[opponentType] = (pM.opponentTypeA[opponentType] || 0) - 1;
+                pM.from[opponentType] = (pM.from[opponentType] || 0) - 1;
             }
             if (matchups.noDamageFrom.includes(opponentType)) {
-                pM.opponentTypeA[opponentType] = (pM.opponentTypeA[opponentType] || 0) - 1;
+                pM.from[opponentType] = (pM.from[opponentType] || 0) - 1;
             }
             // filter out "neutral" matchups
-            if (pM.yourTypeA[yourType] === 0) {
-                delete pM.yourTypeA[yourType];
+            if (pM.to[yourType] === 0) {
+                delete pM.to[yourType];
             }
-            if (pM.opponentTypeA[opponentType] === 0) {
-                delete pM.opponentTypeA[opponentType];
+            if (pM.from[opponentType] === 0) {
+                delete pM.from[opponentType];
             }
         }
     }


### PR DESCRIPTION
I noticed a bug where the analysis would weirdly report a type as both Strong and Weak:
![image](https://user-images.githubusercontent.com/20410434/182035926-f261e9a4-e96f-4f50-a594-15b6c4ce70db.png)

In this example it's because Bug is both strong vs Psychic & weak vs Steel

To fix this I've refactored the matchup logic to a number / points based system. A type with 0 points (AKA neutral) gets filtered out of the final analysis:

![image](https://user-images.githubusercontent.com/20410434/182035949-84428065-79de-49e3-a3a5-39d9d088c78d.png)

The logic has gotten complex to the point I figured it now belongs in its own file outside of the component.