### PR TITLE
Add getter for type version and remove 'types' from Pokemon

### DIFF
--- a/src/components/MatchupAnalysis.vue
+++ b/src/components/MatchupAnalysis.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { defineProps, ref, watch } from 'vue';
 import { HomePageModel } from '@/ts/component_interfaces';
-import { Type } from '@/ts/types';
 import { getPokemonById } from '@/ts/pokemon';
 import { PokemonMatchup, getPokemonMatchup } from '@/ts/pokemon_matchup';
 

--- a/src/ts/pokemon.ts
+++ b/src/ts/pokemon.ts
@@ -1,14 +1,12 @@
 import axios from 'axios';
 import { SelectOption } from './component_interfaces';
-import { Generations } from './generations';
-import { buildFromRawTypes, Type } from './types';
+import { buildFromRawTypes, Type, Versions } from './types';
 
 const BASE_URL = 'https://pokeapi.co/api/v2/';
 
 export interface Pokemon {
     name: string;
-    types: Type[];
-    typeVersions: { [key in Generations]?: Type[] };
+    typeVersions: Versions<Type[]>;
     id: string;
     imageUrl: string;
 }
@@ -24,12 +22,11 @@ export async function getPokemonById(id: string|number): Promise<Pokemon> {
 
     const data = rawPokemonData?.data;
 
-    const typeData = await buildFromRawTypes(data);
+    const typeVersions = await buildFromRawTypes(data);
 
     const pokemon: Pokemon = {
         name: data.name,
-        types: typeData.types,
-        typeVersions: typeData.typeVersions,
+        typeVersions,
         id: data.id,
         imageUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${data.id}.png`,
     };

--- a/src/ts/pokemon_matchup.ts
+++ b/src/ts/pokemon_matchup.ts
@@ -7,8 +7,8 @@ export interface PokemonMatchup {
 }
 
 export function getPokemonMatchup(pokemonYou: Pokemon, pokemonOpponent: Pokemon): PokemonMatchup {
-    const yourTypes = pokemonYou.types;
-    const opponentTypeNames = pokemonOpponent.types.map((type: Type) => type.name);
+    const yourTypes = pokemonYou.typeVersions.latest; // @TODO use generation here
+    const opponentTypeNames = pokemonOpponent.typeVersions.latest.map((type: Type) => type.name);
     const pM: PokemonMatchup = {
         to: {},
         from: {},

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -116,6 +116,11 @@ export async function buildType(type: string, primaryType: boolean): Promise<Typ
 }
 
 function getClosestGen(versions: Versions<unknown>, gen: Generations): Generations {
+    // get the specific gen if it exists
+    if (versions[gen]) {
+        return gen;
+    }
+
     // if not, see if we have the data for any past generations
     const pastGenerations = Object.keys(versions).filter(
         (version) => version !== Generations.GEN_LATEST,

--- a/src/ts/types.ts
+++ b/src/ts/types.ts
@@ -33,22 +33,22 @@ interface DamageMatchups {
     noDamageTo: string[],
 }
 
-interface Versions {
-    [Generations.GEN_LATEST]: DamageMatchups;
-    [Generations.GEN_1]?: DamageMatchups;
-    [Generations.GEN_2]?: DamageMatchups;
-    [Generations.GEN_3]?: DamageMatchups;
-    [Generations.GEN_4]?: DamageMatchups;
-    [Generations.GEN_5]?: DamageMatchups;
-    [Generations.GEN_6]?: DamageMatchups;
-    [Generations.GEN_7]?: DamageMatchups;
-    [Generations.GEN_8]?: DamageMatchups;
+export interface Versions<T> {
+    [Generations.GEN_LATEST]: T;
+    [Generations.GEN_1]?: T;
+    [Generations.GEN_2]?: T;
+    [Generations.GEN_3]?: T;
+    [Generations.GEN_4]?: T;
+    [Generations.GEN_5]?: T;
+    [Generations.GEN_6]?: T;
+    [Generations.GEN_7]?: T;
+    [Generations.GEN_8]?: T;
 }
 
 export interface Type {
     name: string;
     primaryType?: boolean;
-    versions: Versions;
+    versions: Versions<DamageMatchups>;
 }
 
 const cachedTypes: { [key: string]: Type; } = {};
@@ -115,19 +115,14 @@ export async function buildType(type: string, primaryType: boolean): Promise<Typ
     return typeData;
 }
 
-export function getMatchupForGeneration(type: Type, gen: Generations): DamageMatchups {
-    // first see if we have the data for the generation
-    if (type.versions[gen]) {
-        return type.versions[gen] as DamageMatchups;
-    }
-
+function getClosestGen(versions: Versions<unknown>, gen: Generations): Generations {
     // if not, see if we have the data for any past generations
-    const pastGenerations = Object.keys(type.versions).filter(
+    const pastGenerations = Object.keys(versions).filter(
         (version) => version !== Generations.GEN_LATEST,
     );
 
     if (!pastGenerations.length) {
-        return type.versions[Generations.GEN_LATEST] as DamageMatchups;
+        return Generations.GEN_LATEST;
     }
 
     // get the closest higher generation
@@ -140,7 +135,7 @@ export function getMatchupForGeneration(type: Type, gen: Generations): DamageMat
 
     // if its not higher, just return the latest
     if (!closestHigherGen || closestHigherGen < gen) {
-        return type.versions[Generations.GEN_LATEST] as DamageMatchups;
+        return Generations.GEN_LATEST;
     }
 
     // get the closest lower generation
@@ -151,7 +146,17 @@ export function getMatchupForGeneration(type: Type, gen: Generations): DamageMat
         return closest;
     });
 
-    return type.versions[closestLowerGen as Generations] as DamageMatchups;
+    return closestLowerGen as Generations;
+}
+
+export function getMatchupForGeneration(type: Type, gen: Generations): DamageMatchups {
+    const closestGen = getClosestGen(type.versions, gen);
+    return type.versions[closestGen] as DamageMatchups;
+}
+
+export function getTypesForGeneration(typeVersions: Versions<Type[]>, gen: Generations): Type[] {
+    const closestGen = getClosestGen(typeVersions, gen);
+    return typeVersions[closestGen] as Type[];
 }
 
 export async function buildFromRawTypes(rawTypes: RawTypeResponse) {
@@ -164,7 +169,9 @@ export async function buildFromRawTypes(rawTypes: RawTypeResponse) {
         ),
     );
 
-    const typeVersions: { [key in Generations]?: Type[] } = {};
+    const typeVersions: Versions<Type[]> = {
+        [Generations.GEN_LATEST]: types,
+    };
     const promises: Promise<Type>[] = [];
     for (let i = 0; i < rawTypes.past_types.length; i += 1) {
         const gen = convertGenStringToEnum(rawTypes.past_types[i].generation.url);
@@ -185,8 +192,5 @@ export async function buildFromRawTypes(rawTypes: RawTypeResponse) {
     }
     await Promise.all(promises);
 
-    return {
-        types,
-        typeVersions,
-    };
+    return typeVersions;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "CommonJS",
+    "module": "commonjs",
     "strict": true,
     "jsx": "preserve",
     "moduleResolution": "node",


### PR DESCRIPTION
This adds a new function to types.ts which lets you get an array of specific types for a generation

The code is also cleaned up a bit here to move some logic in files it should belong, and turning the versions interface into a generic, meaning we can reuse it both for damage and type versions

I've also removed 'types' from the pokemon interface since we should only need typeVersions

Example:
```js
    const clefairy = await getPokemonById(35);
    console.log(clefairy);
    // an array of 1 type which is normal
    console.log(getTypesForGeneration(clefairy.typeVersions, Generations.GEN_1));
    console.log(getTypesForGeneration(clefairy.typeVersions, Generations.GEN_5));
    // an array of 1 type which is fairy
    console.log(getTypesForGeneration(clefairy.typeVersions, Generations.GEN_6));
    console.log(getTypesForGeneration(clefairy.typeVersions, Generations.GEN_8));
``` 
