### PR TITLE
Add functionality to generation select

### DIFF
--- a/src/components/MatchupAnalysis.vue
+++ b/src/components/MatchupAnalysis.vue
@@ -3,6 +3,7 @@ import { defineProps, ref, watch } from 'vue';
 import { HomePageModel } from '@/ts/component_interfaces';
 import { getPokemonById } from '@/ts/pokemon';
 import { PokemonMatchup, getPokemonMatchup } from '@/ts/pokemon_matchup';
+import { Generations } from '@/ts/generations';
 
 const props = defineProps<{
     modelValue: HomePageModel,
@@ -11,7 +12,7 @@ const isNotReady = ref(true);
 const analysisResults = ref(['']);
 
 watch(props, async () => {
-    const { pokemonYou, pokemonOpponent } = props.modelValue;
+    const { pokemonYou, pokemonOpponent, generation } = props.modelValue;
     isNotReady.value = true;
     const pokemonYouObj = await getPokemonById(pokemonYou);
     const pokemonOpponentObj = await getPokemonById(pokemonOpponent);
@@ -20,7 +21,11 @@ watch(props, async () => {
     const items: string[] = [];
     const yourName = pokemonYouObj.name;
     const opponentName = pokemonOpponentObj.name;
-    const pM: PokemonMatchup = getPokemonMatchup(pokemonYouObj, pokemonOpponentObj);
+    const pM: PokemonMatchup = getPokemonMatchup(
+        pokemonYouObj,
+        pokemonOpponentObj,
+        generation as Generations,
+    );
 
     const toTypes = Object.keys(pM.to);
     for (let index = 0; index < toTypes.length; index += 1) {

--- a/src/components/PokemonPicker.vue
+++ b/src/components/PokemonPicker.vue
@@ -7,7 +7,6 @@ const props = defineProps<{
     modelValue: string,
     options: SelectOption[],
 }>();
-console.log(props);
 const imageURL = computed(() => `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${props.modelValue}.png`);
 
 async function inputChanged(id: string) {

--- a/src/ts/pokemon_matchup.ts
+++ b/src/ts/pokemon_matchup.ts
@@ -1,21 +1,35 @@
+import { Generations } from './generations';
 import { Pokemon } from './pokemon';
-import { Type } from './types';
+import { getMatchupForGeneration, getTypesForGeneration } from './types';
 
 export interface PokemonMatchup {
     to: { [type: string]: number};
     from: { [type: string]: number};
 }
 
-export function getPokemonMatchup(pokemonYou: Pokemon, pokemonOpponent: Pokemon): PokemonMatchup {
-    const yourTypes = pokemonYou.typeVersions.latest; // @TODO use generation here
-    const opponentTypeNames = pokemonOpponent.typeVersions.latest.map((type: Type) => type.name);
+export function getPokemonMatchup(
+    pokemonYou: Pokemon,
+    pokemonOpponent: Pokemon,
+    generation: Generations,
+): PokemonMatchup {
+    const yourTypes = getTypesForGeneration(
+        pokemonYou.typeVersions,
+        generation,
+    );
+    const opponentTypeNames = getTypesForGeneration(
+        pokemonOpponent.typeVersions,
+        generation,
+    ).map((type) => type.name);
     const pM: PokemonMatchup = {
         to: {},
         from: {},
     };
     for (let ii = 0; ii < yourTypes.length; ii += 1) {
         const yourType = yourTypes[ii].name;
-        const matchups = yourTypes[ii].versions.latest; // @TODO use generation here
+        const matchups = getMatchupForGeneration(
+            yourTypes[ii],
+            generation,
+        );
         for (let jj = 0; jj < opponentTypeNames.length; jj += 1) {
             const opponentType = opponentTypeNames[jj];
             if (matchups.doubleDamageTo.includes(opponentType)) {


### PR DESCRIPTION
This adds functionality to the generation picker, loading the correct damage chart for that generation and the correct type for that generation

For example how clefairy used to be a normal type

## For generations where the matchup is impossible

e.g. metagross vs mukrow, for types on pokemon which didn't exist in an earlier generation, these are removed from the calculation


Examples:
<img width="817" alt="image" src="https://user-images.githubusercontent.com/24510197/182190552-898a1fb8-aeed-494a-b143-b26096beb066.png">
<img width="883" alt="image" src="https://user-images.githubusercontent.com/24510197/182190602-426eb98b-9cf6-41ed-929c-b37bc75dd63c.png">
<img width="858" alt="image" src="https://user-images.githubusercontent.com/24510197/182190788-774ee9a1-d34a-4a81-a6aa-b19cb47d7e7c.png">
<img width="835" alt="image" src="https://user-images.githubusercontent.com/24510197/182190969-8861c6a5-8b75-4131-a959-88f7fa7710c5.png">
<img width="824" alt="image" src="https://user-images.githubusercontent.com/24510197/182190985-82843ef5-c3b9-4521-977b-39548e8e6523.png">
