### PR TITLE
Refactor types

### DIFF
--- a/src/ts/generations.ts
+++ b/src/ts/generations.ts
@@ -1,4 +1,6 @@
-/* eslint-disable import/prefer-default-export */
+import axios from 'axios';
+
+// @TODO: support new generations without us having to update this file
 export enum Generations {
     GEN_LATEST = 'latest',
     GEN_1 = 1,
@@ -11,6 +13,8 @@ export enum Generations {
     GEN_8 = 8,
 }
 
+const versionGroupCache: { [key: string]: Generations; } = {};
+
 export function convertGenStringToEnum(gen: string): Generations {
     const genNum = parseInt(
         gen.split('generation/').pop() as string,
@@ -22,4 +26,16 @@ export function convertGenStringToEnum(gen: string): Generations {
     }
 
     return genNum as Generations;
+}
+
+export async function convertVersionGroupStringToEnum(versionGroup: string): Promise<Generations> {
+    const data = (await axios.get(versionGroup))?.data;
+    if (!data) {
+        throw new Error(`Invalid version group: ${versionGroup}`);
+    }
+
+    const gen = convertGenStringToEnum(data.generation.url);
+    versionGroupCache[versionGroup] = gen;
+
+    return gen;
 }

--- a/src/ts/pokemon.ts
+++ b/src/ts/pokemon.ts
@@ -1,12 +1,13 @@
 import axios from 'axios';
 import { SelectOption } from './component_interfaces';
-import { buildFromRawTypes, Type, Versions } from './types';
+import { convertGenStringToEnum, Generations } from './generations';
+import { getTypeVersionsFromName, MinimalTypeInfo, Versions } from './types';
 
 const BASE_URL = 'https://pokeapi.co/api/v2/';
 
 export interface Pokemon {
     name: string;
-    typeVersions: Versions<Type[]>;
+    typeVersions: Versions<MinimalTypeInfo[]>;
     id: string;
     imageUrl: string;
 }
@@ -22,7 +23,44 @@ export async function getPokemonById(id: string|number): Promise<Pokemon> {
 
     const data = rawPokemonData?.data;
 
-    const typeVersions = await buildFromRawTypes(data);
+    const typeVersions: Versions<MinimalTypeInfo[]> = {
+        [Generations.GEN_LATEST]: [],
+    };
+
+    let allTypeNames: string[] = [];
+    for (let i = 0; i < data.types.length; i += 1) {
+        const currentType = data.types[i];
+        allTypeNames.push(currentType.type.name);
+        typeVersions[Generations.GEN_LATEST].push({
+            name: currentType.type.name,
+            primary: currentType.slot === 1,
+        });
+    }
+
+    if (data?.past_types) {
+        for (let i = 0; i < data.past_types.length; i += 1) {
+            const versionInfo = data.past_types[i];
+            const version = convertGenStringToEnum(versionInfo.generation.url);
+            if (!typeVersions[version]) {
+                typeVersions[version] = [];
+            }
+
+            // now loop through the types
+            for (let x = 0; x < versionInfo.types.length; x += 1) {
+                const currentType = versionInfo.types[x];
+                allTypeNames.push(currentType.type.name);
+                typeVersions[version]?.push({
+                    name: currentType.type.name,
+                    primary: currentType.slot === 1,
+                });
+            }
+        }
+    }
+
+    // dedupe all type names
+    allTypeNames = [...new Set(allTypeNames)];
+    // load all the types fully to put them into cache
+    await Promise.all(allTypeNames.map(getTypeVersionsFromName));
 
     const pokemon: Pokemon = {
         name: data.name,

--- a/src/ts/pokemon_matchup.ts
+++ b/src/ts/pokemon_matchup.ts
@@ -1,6 +1,6 @@
 import { Generations } from './generations';
 import { Pokemon } from './pokemon';
-import { getMatchupForGeneration, getTypesForGeneration } from './types';
+import { getTypesForGeneration } from './types';
 
 export interface PokemonMatchup {
     to: { [type: string]: number};
@@ -26,10 +26,7 @@ export function getPokemonMatchup(
     };
     for (let ii = 0; ii < yourTypes.length; ii += 1) {
         const yourType = yourTypes[ii].name;
-        const matchups = getMatchupForGeneration(
-            yourTypes[ii],
-            generation,
-        );
+        const matchups = yourTypes[ii].damageRelations;
         for (let jj = 0; jj < opponentTypeNames.length; jj += 1) {
             const opponentType = opponentTypeNames[jj];
             if (matchups.doubleDamageTo.includes(opponentType)) {


### PR DESCRIPTION
Simplifying how we store type data on a pokemon

Before we duplicated a ton of data and didn't end up really using it at all

This new structure has a better type structure and can be used easier

A type object is now exactly that, just the type info, it doesnt store previous versions of it, simply the info for it and the generation it comes from


Main place to look is the pokemonMatchup.ts file, here we just need to get a type for a generation and it already has the damage calcs for that generation, instead of having all previous gen info on it (which isnt needed)